### PR TITLE
add Promise.resolve & test sync functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ class _Wrapper {
       const toFetch = this.toFetch
       this.toFetch = []
 
-      this.func(toFetch.map((q) => q.id), this.ctx).then((data) => {
+      Promise.resolve(this.func(toFetch.map((q) => q.id), this.ctx)).then((data) => {
         if (!Array.isArray(data) && data.length !== toFetch.length) {
           onError(new Error(`The Number of elements in the response for ${this.key} does not match`))
           return

--- a/test.js
+++ b/test.js
@@ -295,3 +295,31 @@ test('create a Factory that batches with null options', async (t) => {
     { k: 24 }
   ])
 })
+
+test('support sync functions', async (t) => {
+  // plan verifies that fetchSomething is called only once
+  t.plan(2)
+
+  const factory = new Factory()
+
+  factory.add('fetchSomething', (queries) => {
+    t.deepEqual(queries, [
+      42, 24
+    ])
+    return queries.map((k) => {
+      return { k }
+    })
+  })
+
+  const cache = factory.create()
+
+  const p1 = cache.fetchSomething(42)
+  const p2 = cache.fetchSomething(24)
+
+  const res = await Promise.all([p1, p2])
+
+  t.deepEqual(res, [
+    { k: 42 },
+    { k: 24 }
+  ])
+})


### PR DESCRIPTION
fixes #1 

Simply adding `Promise.resolve()` should do the trick to support sync functions without any performance hit, and added a test which is `create a Factory that batches` but removing the `async` keyword to the batch function.