### PR TITLE
Add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "standard | snazzy && tap test.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mcollina/single-user-cache.git"
+  },
   "keywords": [
     "cache",
     "single",


### PR DESCRIPTION
The mercurius documentation links to [https://www.npmjs.com/package/single-user-cache](https://www.npmjs.com/package/single-user-cache). Having the repository url in the package.json would make it easier to find the actual code.