### PR TITLE
Feat: types

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,5 @@
 'use strict'
 
-module.exports = require('neostandard')({})
+module.exports = require('neostandard')({
+  ts: true
+})

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,55 @@
+export type BatchLoadFn<Key, Value, Context = any> = (
+  keys: Array<Key>,
+  context: Context
+) => Promise<Array<Value>>
+
+export type SerializeFn<Key> = (key: Key) => string
+
+export interface Options {
+  /**
+   * cache by default, set to false to just do batching
+   * @default true
+   */
+  cache?: boolean;
+  /**
+   * unlimited batch size by default, set to a number > 0 to split the batches in chunks
+   * @default undefined
+   */
+  maxBatchSize?: number;
+}
+
+export type Cache<MethodMap = {}, Context = any> = MethodMap & {
+  readonly ctx?: Context;
+}
+
+export class Factory<Context = any, MethodMap extends {} = {}> {
+  public constructor ()
+  /**
+   * Registers a data-fetching function.
+   */
+  add<MethodName extends string, Key, Value>(
+    key: MethodName,
+    func: BatchLoadFn<Key, Value, Context>,
+    serialize?: SerializeFn<Key>
+  ): Factory<
+    Context,
+    MethodMap & { [M in MethodName]: (key: Key) => Promise<Value> }
+  >
+  /**
+   * Registers a data-fetching function.
+   */
+  add<MethodName extends string, Key, Value>(
+    key: MethodName,
+    opts: Options,
+    func: BatchLoadFn<Key, Value, Context>,
+    serialize?: SerializeFn<Key>
+  ): Factory<
+    Context,
+    MethodMap & { [M in MethodName]: (key: Key) => Promise<Value> }
+  >
+
+  /**
+   * Creates a cache instance for a single request.
+   */
+  create (ctx?: Context): Cache<MethodMap, Context>
+}

--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ class Factory {
       }
       return this[kValues][key].add(id)
     }
+
+    return this
   }
 
   create (ctx) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,56 @@
+import { expectType } from 'tsd'
+import { Factory } from '.'
+
+interface Post {
+  id: string;
+}
+
+interface Context {
+  requestId: string;
+}
+
+type BatchFn = (key: string) => Promise<Post>
+
+// Serializer
+const f1 = new Factory().add('getPost', async (keys: string[]) =>
+  keys.map(
+    (k) => ({ id: k }),
+    (id: string) => {
+      return id
+    }
+  )
+)
+const c1 = f1.create()
+
+expectType<BatchFn>(c1.getPost)
+expectType<Promise<Post>>(c1.getPost('a'))
+
+// Context
+const f2 = new Factory<Context>().add(
+  'getPost',
+  async (keys: string[], ctx) => {
+    expectType<Context>(ctx)
+    return keys.map((k) => ({ id: k }))
+  }
+)
+const c2 = f2.create({ requestId: '1' })
+
+expectType<BatchFn>(c2.getPost)
+expectType<Promise<Post>>(c2.getPost('a'))
+
+// Context + Options + Serializer
+const f3 = new Factory<Context>().add(
+  'getPost',
+  { cache: true },
+  async (keys: string[], ctx) => {
+    expectType<Context>(ctx)
+    return keys.map((k) => ({ id: k }))
+  },
+  (id: string) => {
+    return id
+  }
+)
+const c3 = f3.create({ requestId: '1' })
+
+expectType<BatchFn>(c3.getPost)
+expectType<Promise<Post>>(c3.getPost('a'))

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "single-user-cache",
   "version": "2.0.0",
   "description": "A cache for a single user",
+  "types": "index.d.ts",
   "main": "index.js",
   "scripts": {
-    "test": "eslint . && node --test test.js"
+    "test": "eslint . && node --test test.js && tsd"
   },
   "repository": {
     "type": "git",
@@ -25,7 +26,8 @@
     "eslint": "^9.26.0",
     "graphql": "^16.8.1",
     "mitata": "^1.0.34",
-    "neostandard": "^0.12.1"
+    "neostandard": "^0.12.1",
+    "tsd": "^0.33.0"
   },
   "dependencies": {
     "safe-stable-stringify": "^2.4.3"


### PR DESCRIPTION
This PR adds typescript definitions to the project.

To have better type inference we also added `return this` to the add method. With this, the returned `Factory` instance will have the appropriate types.

We also added tests using `tsd`.

LMKWYT